### PR TITLE
New PoolUnifRnd struct

### DIFF
--- a/prjn/poolunifrnd.go
+++ b/prjn/poolunifrnd.go
@@ -14,12 +14,10 @@ import (
 	"github.com/goki/ki/ints"
 )
 
-// PoolOneToOne implements one-to-one connectivity between pools within layers.
+// PoolUnifRnd implements random pattern of connectivity between pools within layers.
 // Pools are the outer-most two dimensions of a 4D layer shape.
-// If either layer does not have pools, then if the number of individual
-// units matches the number of pools in the other layer, those are connected one-to-one
-// otherwise each pool connects to the entire set of other units.
-// If neither is 4D, then it is equivalent to OneToOne.
+// If either layer does not have pools, PoolUnifRnd works as UnifRnd does.
+// If probability of connection (PCon) is 1, PoolUnifRnd works as PoolOnetoOne does.
 type PoolUnifRnd struct {
 	PoolOneToOne
 	UnifRnd
@@ -38,23 +36,11 @@ func (ur *PoolUnifRnd) Name() string {
 func (ur *PoolUnifRnd) Connect(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
 	if send.NumDims() == 4 && recv.NumDims() == 4 {
 		return ur.ConnectPoolsRnd(send, recv, same)
-	} else {
-		return ur.ConnectRnd(send, recv, same)
 	}
-	// switch {
-	// case send.NumDims() == 4 && recv.NumDims() == 4:
-	// 	return ur.ConnectPools(send, recv, same)
-	// case send.NumDims() == 2 && recv.NumDims() == 4:
-	// 	return ur.ConnectRecvPool(send, recv, same)
-	// case send.NumDims() == 4 && recv.NumDims() == 2:
-	// 	return ur.ConnectSendPool(send, recv, same)
-	// case send.NumDims() == 2 && recv.NumDims() == 2:
-	// 	return ur.ConnectOneToOne(send, recv, same)
-	// }
-	// return
+	return ur.ConnectRnd(send, recv, same)
 }
 
-// ConnectPools is when both recv and send have pools
+// ConnectPoolsRnd is when both recv and send have pools
 func (ur *PoolUnifRnd) ConnectPoolsRnd(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
 	if ur.PCon >= 1 {
 		return ur.ConnectPools(send, recv, same)
@@ -106,7 +92,8 @@ func (ur *PoolUnifRnd) ConnectPoolsRnd(send, recv *etensor.Shape, same bool) (se
 			if noself { // need to exclude ri
 				ix := 0
 				for j := 0; j < sNu; j++ {
-					if j != ri {
+					ji := spi*sNu + j
+					if ji != ri {
 						sorder[ix] = j
 						ix++
 					}
@@ -138,7 +125,7 @@ func (ur *PoolUnifRnd) ConnectPoolsRnd(send, recv *etensor.Shape, same bool) (se
 	return
 }
 
-// copy of UnifRnd.Connect
+// ConnectRnd is a copy of UnifRnd.Connect with initial if statement modified
 func (ur *PoolUnifRnd) ConnectRnd(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
 	if ur.PCon >= 1 {
 		switch {

--- a/prjn/poolunifrnd.go
+++ b/prjn/poolunifrnd.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2019, The Emergent Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package prjn
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+
+	"github.com/emer/emergent/erand"
+	"github.com/emer/etable/etensor"
+	"github.com/goki/ki/ints"
+)
+
+// PoolOneToOne implements one-to-one connectivity between pools within layers.
+// Pools are the outer-most two dimensions of a 4D layer shape.
+// If either layer does not have pools, then if the number of individual
+// units matches the number of pools in the other layer, those are connected one-to-one
+// otherwise each pool connects to the entire set of other units.
+// If neither is 4D, then it is equivalent to OneToOne.
+type PoolUnifRnd struct {
+	PoolOneToOne
+	UnifRnd
+}
+
+func NewPoolUnifRnd() *PoolUnifRnd {
+	newur := &PoolUnifRnd{}
+	newur.PCon = 0.5
+	return newur
+}
+
+func (ur *PoolUnifRnd) Name() string {
+	return "PoolUnifRnd"
+}
+
+func (ur *PoolUnifRnd) Connect(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
+	if send.NumDims() == 4 && recv.NumDims() == 4 {
+		return ur.ConnectPoolsRnd(send, recv, same)
+	} else {
+		return ur.ConnectRnd(send, recv, same)
+	}
+	// switch {
+	// case send.NumDims() == 4 && recv.NumDims() == 4:
+	// 	return ur.ConnectPools(send, recv, same)
+	// case send.NumDims() == 2 && recv.NumDims() == 4:
+	// 	return ur.ConnectRecvPool(send, recv, same)
+	// case send.NumDims() == 4 && recv.NumDims() == 2:
+	// 	return ur.ConnectSendPool(send, recv, same)
+	// case send.NumDims() == 2 && recv.NumDims() == 2:
+	// 	return ur.ConnectOneToOne(send, recv, same)
+	// }
+	// return
+}
+
+// ConnectPools is when both recv and send have pools
+func (ur *PoolUnifRnd) ConnectPoolsRnd(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
+	if ur.PCon >= 1 {
+		return ur.ConnectPools(send, recv, same)
+	}
+	sendn, recvn, cons = NewTensors(send, recv)
+	sNtot := send.Len()
+	// rNtot := recv.Len()
+	sNp := send.Dim(0) * send.Dim(1)
+	rNp := recv.Dim(0) * recv.Dim(1)
+	sNu := send.Dim(2) * send.Dim(3)
+	rNu := recv.Dim(2) * recv.Dim(3)
+	rnv := recvn.Values
+	snv := sendn.Values
+	npl := rNp
+
+	noself := same && !ur.SelfCon
+	var nsend int
+	if noself {
+		nsend = int(math.Round(float64(ur.PCon) * float64(sNu-1)))
+	} else {
+		nsend = int(math.Round(float64(ur.PCon) * float64(sNu)))
+	}
+
+	if ur.RndSeed == 0 {
+		ur.RndSeed = int64(rand.Uint64())
+	}
+	rand.Seed(ur.RndSeed)
+
+	sordlen := sNu
+	if noself {
+		sordlen--
+	}
+
+	sorder := rand.Perm(sordlen)
+	slist := make([]int, nsend)
+
+	if ur.NPools > 0 {
+		npl = ints.MinInt(ur.NPools, rNp)
+	}
+	for i := 0; i < npl; i++ {
+		rpi := ur.RecvStart + i
+		spi := ur.SendStart + i
+		if rpi >= rNp || spi >= sNp {
+			break
+		}
+		for rui := 0; rui < rNu; rui++ {
+			ri := rpi*rNu + rui
+			rnv[ri] = int32(nsend)
+			if noself { // need to exclude ri
+				ix := 0
+				for j := 0; j < sNu; j++ {
+					if j != ri {
+						sorder[ix] = j
+						ix++
+					}
+				}
+				erand.PermuteInts(sorder)
+			}
+			copy(slist, sorder)
+			sort.Ints(slist)
+			for sui := 0; sui < nsend; sui++ {
+				si := spi*sNu + slist[sui]
+				off := ri*sNtot + si
+				cons.Values.Set(off, true)
+			}
+			erand.PermuteInts(sorder)
+		}
+		for sui := 0; sui < sNu; sui++ {
+			nr := 0
+			si := spi*sNu + sui
+			for rui := 0; rui < rNu; rui++ {
+				ri := rpi*rNu + rui
+				off := ri*sNtot + si
+				if cons.Values.Index(off) {
+					nr++
+				}
+			}
+			snv[si] = int32(nr)
+		}
+	}
+	return
+}
+
+// copy of UnifRnd.Connect
+func (ur *PoolUnifRnd) ConnectRnd(send, recv *etensor.Shape, same bool) (sendn, recvn *etensor.Int32, cons *etensor.Bits) {
+	if ur.PCon >= 1 {
+		switch {
+		case send.NumDims() == 2 && recv.NumDims() == 4:
+			return ur.ConnectRecvPool(send, recv, same)
+		case send.NumDims() == 4 && recv.NumDims() == 2:
+			return ur.ConnectSendPool(send, recv, same)
+		case send.NumDims() == 2 && recv.NumDims() == 2:
+			return ur.ConnectOneToOne(send, recv, same)
+		}
+	}
+	if ur.Recip {
+		return ur.ConnectRecip(send, recv, same)
+	}
+	sendn, recvn, cons = NewTensors(send, recv)
+	slen := send.Len()
+	rlen := recv.Len()
+
+	noself := same && !ur.SelfCon
+	var nsend int
+	if noself {
+		nsend = int(math.Round(float64(ur.PCon) * float64(slen-1)))
+	} else {
+		nsend = int(math.Round(float64(ur.PCon) * float64(slen)))
+	}
+
+	// NOTE: this is reasonably accurate: mean + 3 * SEM, but we can just use
+	// empirical values more easily and safely.
+
+	// recv number is even distribution across recvs plus some imbalance factor
+	// nrMean := float32(rlen*nsend) / float32(slen)
+	// // add 3 * SEM as corrective factor
+	// nrSEM := nrMean / math32.Sqrt(nrMean)
+	// nrecv := int(nrMean + 3*nrSEM)
+	// if nrecv > rlen {
+	// 	nrecv = rlen
+	// }
+
+	rnv := recvn.Values
+	for i := range rnv {
+		rnv[i] = int32(nsend)
+	}
+
+	if ur.RndSeed == 0 {
+		ur.RndSeed = int64(rand.Uint64())
+	}
+	rand.Seed(ur.RndSeed)
+
+	sordlen := slen
+	if noself {
+		sordlen--
+	}
+
+	sorder := rand.Perm(sordlen)
+	slist := make([]int, nsend)
+	for ri := 0; ri < rlen; ri++ {
+		if noself { // need to exclude ri
+			ix := 0
+			for j := 0; j < slen; j++ {
+				if j != ri {
+					sorder[ix] = j
+					ix++
+				}
+			}
+			erand.PermuteInts(sorder)
+		}
+		copy(slist, sorder)
+		sort.Ints(slist) // keep list sorted for more efficient memory traversal etc
+		for si := 0; si < nsend; si++ {
+			off := ri*slen + slist[si]
+			cons.Values.Set(off, true)
+		}
+		erand.PermuteInts(sorder)
+	}
+
+	// 	set send n's empirically
+	snv := sendn.Values
+	for si := range snv {
+		nr := 0
+		for ri := 0; ri < rlen; ri++ {
+			off := ri*slen + si
+			if cons.Values.Index(off) {
+				nr++
+			}
+		}
+		snv[si] = int32(nr)
+	}
+	return
+}

--- a/prjn/prjn_test.go
+++ b/prjn/prjn_test.go
@@ -284,3 +284,93 @@ func TestUnifRndSelf(t *testing.T) {
 	fmt.Printf("sendn: %v\n", sendn.Values)
 	fmt.Printf("unif rnd rNtot: %d  pcon: %g  max: %d  min: %d  mean: %g\n", rNtot, pj.PCon, nrMax, nrMin, float32(nrMean)/float32(sNtot))
 }
+
+func TestPoolUnifRnd(t *testing.T) {
+	send := etensor.NewShape([]int{2, 3, 2, 3}, nil, nil)
+	recv := etensor.NewShape([]int{2, 3, 3, 4}, nil, nil)
+
+	sNtot := send.Len()
+	rNtot := recv.Len()
+
+	pj := NewPoolUnifRnd()
+	pj.PCon = 0.5
+	sendn, recvn, cons := pj.Connect(send, recv, false)
+	fmt.Printf("unif rnd recv: 2x3x3x4 send: 2x3x2x3\n%s\n", string(ConsStringFull(send, recv, cons)))
+
+	_ = recvn
+
+	nrMax := 0
+	nrMin := rNtot
+	nrMean := 0
+	for si := 0; si < sNtot; si++ {
+		nr := int(sendn.Values[si])
+		nrMax = ints.MaxInt(nrMax, nr)
+		nrMin = ints.MinInt(nrMin, nr)
+		nrMean += nr
+	}
+	fmt.Printf("sendn: %v\n", sendn.Values)
+	fmt.Printf("unif rnd rNtot: %d  pcon: %g  max: %d  min: %d  mean: %g\n", rNtot, pj.PCon, nrMax, nrMin, float32(nrMean)/float32(sNtot))
+
+	// now test recip
+	// rpj := NewUnifRnd()
+	// rpj.PCon = 0.5
+	// rpj.Recip = true
+	// sendn, recvn, cons = rpj.Connect(send, recv, false)
+	// fmt.Printf("unif rnd recip recv: 3x4 send: 2x3\n%s\n", string(ConsStringFull(send, recv, cons)))
+
+	// _ = recvn
+}
+
+func TestPoolUnifRndLg(t *testing.T) {
+	send := etensor.NewShape([]int{2, 3, 20, 30}, nil, nil)
+	recv := etensor.NewShape([]int{2, 3, 30, 40}, nil, nil)
+
+	sNtot := send.Len()
+	rNtot := recv.Len()
+
+	pj := NewPoolUnifRnd()
+	pj.PCon = 0.05
+	sendn, recvn, cons := pj.Connect(send, recv, false)
+
+	_ = recvn
+	_ = cons
+
+	nrMax := 0
+	nrMin := rNtot
+	nrMean := 0
+	for si := 0; si < sNtot; si++ {
+		nr := int(sendn.Values[si])
+		nrMax = ints.MaxInt(nrMax, nr)
+		nrMin = ints.MinInt(nrMin, nr)
+		nrMean += nr
+	}
+	fmt.Printf("unif rnd large rNtot: %d  pcon: %g  max: %d  min: %d  mean: %g\n", rNtot, pj.PCon, nrMax, nrMin, float32(nrMean)/float32(sNtot))
+}
+
+func TestPoolUnifRndSelf(t *testing.T) {
+	send := etensor.NewShape([]int{2, 3, 2, 3}, nil, nil)
+	recv := etensor.NewShape([]int{2, 3, 2, 3}, nil, nil)
+
+	sNtot := send.Len()
+	rNtot := recv.Len()
+
+	pj := NewPoolUnifRnd()
+	pj.PCon = 0.5
+	pj.SelfCon = false
+	sendn, recvn, cons := pj.Connect(send, recv, true)
+	fmt.Printf("unif rnd self: 2x3x2x3\n%s\n", string(ConsStringFull(send, recv, cons)))
+
+	_ = recvn
+
+	nrMax := 0
+	nrMin := rNtot
+	nrMean := 0
+	for si := 0; si < sNtot; si++ {
+		nr := int(sendn.Values[si])
+		nrMax = ints.MaxInt(nrMax, nr)
+		nrMin = ints.MinInt(nrMin, nr)
+		nrMean += nr
+	}
+	fmt.Printf("sendn: %v\n", sendn.Values)
+	fmt.Printf("unif rnd rNtot: %d  pcon: %g  max: %d  min: %d  mean: %g\n", rNtot, pj.PCon, nrMax, nrMin, float32(nrMean)/float32(sNtot))
+}


### PR DESCRIPTION
This can create UnifRnd prjns between layers both of which have pooled 4D structure. As of now, PoolUnifRnd enables to simulate a hip model with pooled DG CA3.