### PR TITLE
Accommodate "set scale" (2 parameter) weights when loading a CEmer weights file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/emer/emergent
+module github.com/rgobbel/emergent
 
 go 1.13
 

--- a/weights/cpp.go
+++ b/weights/cpp.go
@@ -92,6 +92,7 @@ func NetReadCpp(r io.Reader) (*Network, error) {
 			if len(rw.Si) != nc {
 				rw.Si = make([]int, nc)
 				rw.Wt = make([]float32, nc)
+				rw.Scale = make([]float32, nc)
 			}
 			cidx = 0 // start reading on next ones
 			continue
@@ -121,23 +122,43 @@ func NetReadCpp(r io.Reader) (*Network, error) {
 			continue
 		default: // weight values read into current rw
 			siwts := strings.Split(bs, " ")
-			if len(siwts) != 2 {
+			switch len(siwts) {
+			case 2:
+				si, err := strconv.Atoi(siwts[0])
+				if err != nil {
+					errlist = append(errlist, err)
+				}
+				wt, err := strconv.ParseFloat(siwts[1], 32)
+				if err != nil {
+					errlist = append(errlist, err)
+				}
+				rw.Si[cidx] = si
+				rw.Wt[cidx] = float32(wt)
+				rw.Scale[cidx] = float32(0)
+				cidx++
+			case 3:
+				si, err := strconv.Atoi(siwts[0])
+				if err != nil {
+					errlist = append(errlist, err)
+				}
+				wt, err := strconv.ParseFloat(siwts[1], 32)
+				if err != nil {
+					errlist = append(errlist, err)
+				}
+				scale, err := strconv.ParseFloat(siwts[2], 32)
+				if err != nil {
+					errlist = append(errlist, err)
+				}
+				rw.Si[cidx] = si
+				rw.Wt[cidx] = float32(wt)
+				rw.Scale[cidx] = float32(scale)
+				cidx++
+			default:
 				err = fmt.Errorf("NetReadCpp: unrecognized input: %v", bs)
 				errlist = append(errlist, err)
 				log.Println(err)
 				continue
 			}
-			si, err := strconv.Atoi(siwts[0])
-			if err != nil {
-				errlist = append(errlist, err)
-			}
-			wt, err := strconv.ParseFloat(siwts[1], 32)
-			if err != nil {
-				errlist = append(errlist, err)
-			}
-			rw.Si[cidx] = si
-			rw.Wt[cidx] = float32(wt)
-			cidx++
 		}
 	}
 	var eall error

--- a/weights/cpp_test.go
+++ b/weights/cpp_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCppOpenWts(t *testing.T) {
-	fp, err := os.Open("FaceNetworkCpp.wts")
+	fp, err := os.Open("PVLVNet.wts")
 	defer fp.Close()
 	if err != nil {
 		t.Error(err)

--- a/weights/wts.go
+++ b/weights/wts.go
@@ -48,8 +48,9 @@ func (pj *Prjn) SetMetaData(key, val string) {
 
 // Recv is temp structure for holding decoded weights, one for each recv unit
 type Recv struct {
-	Ri int
-	N  int
-	Si []int
-	Wt []float32
+	Ri    int
+	N     int
+	Si    []int
+	Wt    []float32
+	Scale []float32
 }


### PR DESCRIPTION
Weights with the "set scale" option are dumped with both a weight and a scale value. This adds code to deal with that. go.mod changes were done so I could use the modified code in my Go environment and should be filtered out. Test code refers to a file that I'm not checking in due to its size, but can be generated by dumping weights from the BVPVLV model.