### PR TITLE
Rm SendPrjns&RecvPrjns from Layer interface

### DIFF
--- a/emer/layer.go
+++ b/emer/layer.go
@@ -5,6 +5,7 @@
 package emer
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/emer/emergent/params"
@@ -202,6 +203,18 @@ type Layer interface {
 	// SendPrjn returns a specific sending projection
 	SendPrjn(idx int) Prjn
 
+	// SendNameTry looks for a projection connected to this layer whose sender layer has a given name
+	SendNameTry(sender string) (Prjn, error)
+
+	// SendNameTypeTry looks for a projection connected to this layer whose sender layer has a given name and type
+	SendNameTypeTry(sender, typ string) (Prjn, error)
+
+	// RecvNameTry looks for a projection connected to this layer whose receiver layer has a given name
+	RecvNameTry(recv string) (Prjn, error)
+
+	// RecvNameTypeTry looks for a projection connected to this layer whose receiver layer has a given name and type
+	RecvNameTypeTry(recv, typ string) (Prjn, error)
+
 	// RecvPrjnVals fills in values of given synapse variable name,
 	// for projection from given sending layer and neuron 1D index,
 	// for all receiving neurons in this layer,
@@ -351,3 +364,45 @@ const (
 
 	LayerTypeN
 )
+
+// we keep these here to make it easier for other packages to implement the emer.Layer interface
+// by just calling these methods
+func SendNameTry(l Layer, sender string) (Prjn, error) {
+	for pi := 0; pi < l.NRecvPrjns(); pi++ {
+		pj := l.RecvPrjn(pi)
+		if pj.SendLay().Name() == sender {
+			return pj, nil
+		}
+	}
+	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
+}
+
+func RecvNameTry(l Layer, recv string) (Prjn, error) {
+	for pi := 0; pi < l.NSendPrjns(); pi++ {
+		pj := l.SendPrjn(pi)
+		if pj.RecvLay().Name() == recv {
+			return pj, nil
+		}
+	}
+	return nil, fmt.Errorf("receiving layer: %v not found in list of projections", recv)
+}
+
+func SendNameTypeTry(l Layer, sender, typ string) (Prjn, error) {
+	for pi := 0; pi < l.NRecvPrjns(); pi++ {
+		pj := l.RecvPrjn(pi)
+		if pj.SendLay().Name() == sender && pj.PrjnTypeName() == typ {
+			return pj, nil
+		}
+	}
+	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
+}
+
+func RecvNameTypeTry(l Layer, recv, typ string) (Prjn, error) {
+	for pi := 0; pi < l.NSendPrjns(); pi++ {
+		pj := l.SendPrjn(pi)
+		if pj.RecvLay().Name() == recv && pj.PrjnTypeName() == typ {
+			return pj, nil
+		}
+	}
+	return nil, fmt.Errorf("receiving layer: %v, type: %v not found in list of projections", recv, typ)
+}

--- a/emer/layer.go
+++ b/emer/layer.go
@@ -190,17 +190,11 @@ type Layer interface {
 	// Returns NaN on invalid var name or index.
 	UnitVal(varNm string, idx []int) float32
 
-	// RecvPrjns returns the full list of receiving projections
-	RecvPrjns() *Prjns
-
 	// NRecvPrjns returns the number of receiving projections
 	NRecvPrjns() int
 
 	// RecvPrjn returns a specific receiving projection
 	RecvPrjn(idx int) Prjn
-
-	// SendPrjns returns the full list of sending projections
-	SendPrjns() *Prjns
 
 	// NSendPrjns returns the number of sending projections
 	NSendPrjns() int

--- a/netview/netdata.go
+++ b/netview/netdata.go
@@ -390,46 +390,6 @@ func (nd *NetData) UnitValIdx(laynm string, vnm string, uidx1d int, ridx int) (f
 	return val, true
 }
 
-func SendNameTry(l emer.Layer, sender string) (emer.Prjn, error) {
-	for pi := 0; pi < l.NRecvPrjns(); pi++ {
-		pj := l.RecvPrjn(pi)
-		if pj.SendLay().Name() == sender {
-			return pj, nil
-		}
-	}
-	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
-}
-
-func RecvNameTry(l emer.Layer, recv string) (emer.Prjn, error) {
-	for pi := 0; pi < l.NSendPrjns(); pi++ {
-		pj := l.SendPrjn(pi)
-		if pj.RecvLay().Name() == recv {
-			return pj, nil
-		}
-	}
-	return nil, fmt.Errorf("receiving layer: %v not found in list of projections", recv)
-}
-
-func SendNameTypeTry(l emer.Layer, sender, typ string) (emer.Prjn, error) {
-	for pi := 0; pi < l.NRecvPrjns(); pi++ {
-		pj := l.RecvPrjn(pi)
-		if pj.SendLay().Name() == sender && pj.PrjnTypeName() == typ {
-			return pj, nil
-		}
-	}
-	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
-}
-
-func RecvNameTypeTry(l emer.Layer, recv, typ string) (emer.Prjn, error) {
-	for pi := 0; pi < l.NSendPrjns(); pi++ {
-		pj := l.SendPrjn(pi)
-		if pj.RecvLay().Name() == recv && pj.PrjnTypeName() == typ {
-			return pj, nil
-		}
-	}
-	return nil, fmt.Errorf("receiving layer: %v, type: %v not found in list of projections", recv, typ)
-}
-
 // RecvUnitVal returns the value for given layer, variable name, unit index,
 // for receiving projection variable, based on recorded synaptic projection data.
 // Returns false if value unavailable for any reason (including recorded as such as NaN).
@@ -445,12 +405,12 @@ func (nd *NetData) RecvUnitVal(laynm string, vnm string, uidx1d int) (float32, b
 	var pj emer.Prjn
 	var err error
 	if nd.PrjnType != "" {
-		pj, err = SendNameTypeTry(recvLay, laynm, nd.PrjnType)
+		pj, err = recvLay.SendNameTypeTry(laynm, nd.PrjnType)
 		if pj == nil {
-			pj, err = SendNameTry(recvLay, laynm)
+			pj, err = recvLay.SendNameTry(laynm)
 		}
 	} else {
-		pj, err = SendNameTry(recvLay, laynm)
+		pj, err = emer.SendNameTry(recvLay, laynm)
 	}
 	if pj == nil {
 		return 0, false
@@ -493,12 +453,12 @@ func (nd *NetData) SendUnitVal(laynm string, vnm string, uidx1d int) (float32, b
 	var pj emer.Prjn
 	var err error
 	if nd.PrjnType != "" {
-		pj, err = RecvNameTypeTry(sendLay, laynm, nd.PrjnType)
+		pj, err = sendLay.RecvNameTypeTry(laynm, nd.PrjnType)
 		if pj == nil {
-			pj, err = RecvNameTry(sendLay, laynm)
+			pj, err = sendLay.RecvNameTry(laynm)
 		}
 	} else {
-		pj, err = RecvNameTry(sendLay, laynm)
+		pj, err = sendLay.RecvNameTry(laynm)
 	}
 	if pj == nil {
 		return 0, false

--- a/netview/netdata.go
+++ b/netview/netdata.go
@@ -390,7 +390,7 @@ func (nd *NetData) UnitValIdx(laynm string, vnm string, uidx1d int, ridx int) (f
 	return val, true
 }
 
-func sendNameTry(l emer.Layer, sender string) (emer.Prjn, error) {
+func SendNameTry(l emer.Layer, sender string) (emer.Prjn, error) {
 	for pi := 0; pi < l.NRecvPrjns(); pi++ {
 		pj := l.RecvPrjn(pi)
 		if pj.SendLay().Name() == sender {
@@ -400,7 +400,7 @@ func sendNameTry(l emer.Layer, sender string) (emer.Prjn, error) {
 	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
 }
 
-func recvNameTry(l emer.Layer, recv string) (emer.Prjn, error) {
+func RecvNameTry(l emer.Layer, recv string) (emer.Prjn, error) {
 	for pi := 0; pi < l.NSendPrjns(); pi++ {
 		pj := l.SendPrjn(pi)
 		if pj.RecvLay().Name() == recv {
@@ -410,7 +410,7 @@ func recvNameTry(l emer.Layer, recv string) (emer.Prjn, error) {
 	return nil, fmt.Errorf("receiving layer: %v not found in list of projections", recv)
 }
 
-func sendNameTypeTry(l emer.Layer, sender, typ string) (emer.Prjn, error) {
+func SendNameTypeTry(l emer.Layer, sender, typ string) (emer.Prjn, error) {
 	for pi := 0; pi < l.NRecvPrjns(); pi++ {
 		pj := l.RecvPrjn(pi)
 		if pj.SendLay().Name() == sender && pj.PrjnTypeName() == typ {
@@ -420,7 +420,7 @@ func sendNameTypeTry(l emer.Layer, sender, typ string) (emer.Prjn, error) {
 	return nil, fmt.Errorf("sending layer: %v not found in list of projections", sender)
 }
 
-func recvNameTypeTry(l emer.Layer, recv, typ string) (emer.Prjn, error) {
+func RecvNameTypeTry(l emer.Layer, recv, typ string) (emer.Prjn, error) {
 	for pi := 0; pi < l.NSendPrjns(); pi++ {
 		pj := l.SendPrjn(pi)
 		if pj.RecvLay().Name() == recv && pj.PrjnTypeName() == typ {
@@ -445,12 +445,12 @@ func (nd *NetData) RecvUnitVal(laynm string, vnm string, uidx1d int) (float32, b
 	var pj emer.Prjn
 	var err error
 	if nd.PrjnType != "" {
-		pj, err = sendNameTypeTry(recvLay, laynm, nd.PrjnType)
+		pj, err = SendNameTypeTry(recvLay, laynm, nd.PrjnType)
 		if pj == nil {
-			pj, err = sendNameTry(recvLay, laynm)
+			pj, err = SendNameTry(recvLay, laynm)
 		}
 	} else {
-		pj, err = sendNameTry(recvLay, laynm)
+		pj, err = SendNameTry(recvLay, laynm)
 	}
 	if pj == nil {
 		return 0, false
@@ -493,12 +493,12 @@ func (nd *NetData) SendUnitVal(laynm string, vnm string, uidx1d int) (float32, b
 	var pj emer.Prjn
 	var err error
 	if nd.PrjnType != "" {
-		pj, err = recvNameTypeTry(sendLay, laynm, nd.PrjnType)
+		pj, err = RecvNameTypeTry(sendLay, laynm, nd.PrjnType)
 		if pj == nil {
-			pj, err = recvNameTry(sendLay, laynm)
+			pj, err = RecvNameTry(sendLay, laynm)
 		}
 	} else {
-		pj, err = recvNameTry(sendLay, laynm)
+		pj, err = RecvNameTry(sendLay, laynm)
 	}
 	if pj == nil {
 		return 0, false

--- a/netview/prjndata.go
+++ b/netview/prjndata.go
@@ -23,16 +23,16 @@ type LayData struct {
 func (ld *LayData) AllocSendPrjns(ly emer.Layer) {
 	nsp := ly.NSendPrjns()
 	if len(ld.SendPrjns) == nsp {
-		sp := ly.SendPrjns()
-		for si, pj := range *sp {
+		for si := 0; si < ly.NSendPrjns(); si++ {
+			pj := ly.SendPrjn(si)
 			spd := ld.SendPrjns[si]
 			spd.Prjn = pj
 		}
 		return
 	}
 	ld.SendPrjns = make([]*PrjnData, nsp)
-	sp := ly.SendPrjns()
-	for si, pj := range *sp {
+	for si := 0; si < ly.NSendPrjns(); si++ {
+		pj := ly.SendPrjn(si)
 		pd := &PrjnData{Send: pj.SendLay().Name(), Recv: pj.RecvLay().Name(), Prjn: pj}
 		ld.SendPrjns[si] = pd
 		pd.Alloc()


### PR DESCRIPTION
I made sure that these are the only usages of the methods inside `emergent`, but is there any other way to test whether the code is fine?

Background: We want to rm these two functions, since they're barely used anyway and prevent us from writing code that is specialized to the specific layer types we use in Axon.