### PR TITLE
Fix UnifRnd when PCon >= 1

### DIFF
--- a/prjn/unifrnd.go
+++ b/prjn/unifrnd.go
@@ -190,12 +190,12 @@ func (ur *UnifRnd) ConnectFull(send, recv *etensor.Shape, same bool) (sendn, rec
 	nsend := send.Len()
 	nrecv := recv.Len()
 	if same && !ur.SelfCon {
-		nsend--
-		nrecv--
 		for i := 0; i < nsend; i++ { // nsend = nrecv
 			off := i*nsend + i
 			cons.Values.Set(off, false)
 		}
+		nsend--
+		nrecv--
 	}
 	rnv := recvn.Values
 	for i := range rnv {


### PR DESCRIPTION
I found a bug in the UnifRnd patterns that happens when it tries to create a full connectivity pattern (PCon >= 1).

This pull request fixes it.

Example of the bug:
```
// The first example is with a Full pattern, while the second is with UnifRnd with PCon = 1:
full no self con 2x3
0 1 1 1 1 1 
1 0 1 1 1 1 
1 1 0 1 1 1 
1 1 1 0 1 1 
1 1 1 1 0 1 
1 1 1 1 1 0 

full rnd no self con 2x3
0 1 1 1 1 1 
0 1 1 1 1 1 
0 1 1 1 1 1 
0 1 1 1 1 1 
0 1 1 1 1 1 
1 1 1 1 1 1
```